### PR TITLE
remove video iFrame

### DIFF
--- a/modsParser/index.html
+++ b/modsParser/index.html
@@ -4,7 +4,6 @@
 
     <head>
         <title>Space Engineers Mods Parser</title>
-        <iframe src="https://dev.vidby.com/order/W081539/embed" width="500px" height="440px" allowfullscreen frameborder="0" ></iframe>
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     </head>
 


### PR DESCRIPTION
Could we do this iFrame video under a different folder and remove it for the modParser app?

modParser is very useful and I use it each year.

Suppose you prefer to leave iFrame in place, Am I free to copy the contents of the modParser app and move them under my domain?